### PR TITLE
Extend FilterOperator types

### DIFF
--- a/lib/types/filterOperator.ts
+++ b/lib/types/filterOperator.ts
@@ -7,6 +7,7 @@ export type FilterOperator =
   | "ne"
   | "in"
   | "like"
-  | "likeAny";
+  | "likeAny"
+  | "exist";
 
 export const ARRAY_RETURN_TYPE_OPERATORS: FilterOperator[] = ["in", "likeAny"];


### PR DESCRIPTION
is used to check that associated record exists